### PR TITLE
add actionable_message_for_me? to MessageHelper

### DIFF
--- a/lib/discord_ex/client/helpers/message_helper.ex
+++ b/lib/discord_ex/client/helpers/message_helper.ex
@@ -73,4 +73,43 @@ defmodule DiscordEx.Client.Helpers.MessageHelper do
       |> User.dm_channels
       |> Enum.find(fn(c) -> String.to_integer(c["id"]) == channel_id end)
   end
+
+  @doc """
+  Actionable Mention and DM Message
+
+  This checks that an incoming message is private or is a mention to the current user.
+
+  ## Parameters
+
+    - payload: Data from the triggered event.
+    - state: Current state of bot.
+
+  ## Example
+
+      MessageHelper.actionable_message_for_me?(payload, state)
+      #=> true
+  """
+  @spec actionable_message_for_me?(map, map) :: boolean
+  def actionable_message_for_me?(payload, state) do
+
+    #  I'm using here to_string()s because sometimes some IDs are
+    #  provided as quoted string (eg. User.current) and sometimes as Integer.
+
+    my_id = User.current(state[:rest_client])["id"]
+    author_id = payload.data["author"]["id"]
+    channel_id  = payload.data["channel_id"]
+    mentions    = payload.data["mentions"]
+
+    if to_string(author_id) != to_string(my_id) do
+      _message_in_private_channel?(channel_id, state) || _message_mentions_me?(mentions, my_id)
+    else
+      false
+    end
+  end
+
+  defp _message_mentions_me?(mentions, my_id) do
+    Enum.find mentions, fn(m) ->
+      to_string(m["id"]) == to_string(my_id)
+    end
+  end
 end


### PR DESCRIPTION
This adds `actionable_message_for_me?` that compares current user ID with list of mentioned IDs (and also checks DM).

pros:
- you don't need to provide your bot name here
- it's more reliable, because names can be changed (and spoofed)
