### PR TITLE
#9 but better

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Alright you are done. Go forth and prosper!
 
 **As a note your bot_client is a gen_server that will have state properties that contain:**
 
+**:client_id** - your ClientID, so you don't have to constantly ask API for it
+
 **:rest_client** - you can use this process to make calls without having to setup another rest client connection. So in your callback you can do this in your callback with ease:
 
 ```elixir
@@ -83,6 +85,7 @@ alias DiscordEx.RestClient.Resources.User
 
 User.current(state[:rest_client])
 ```
+
 
 ## Voice Client Usage
 

--- a/lib/discord_ex/client/client.ex
+++ b/lib/discord_ex/client/client.ex
@@ -39,6 +39,17 @@ defmodule DiscordEx.Client do
     {:ok, rest_client} = DiscordEx.RestClient.start_link(%{token: opts[:token]})
     opts = Map.put(opts, :rest_client, rest_client)
 
+    id = DiscordEx.RestClient.Resources.User.current(rest_client)["id"]
+    # for more info about below `if` see #11 in GitHub:
+    id =
+      if ! is_integer(id) do
+        {int_id, _} = Integer.parse(id)
+        int_id
+      else
+        id
+      end
+    opts = Map.put(opts, :client_id, id)
+
     :crypto.start()
     :ssl.start()
     :websocket_client.start_link(socket_url(opts), __MODULE__,opts)

--- a/lib/discord_ex/client/helpers/message_helper.ex
+++ b/lib/discord_ex/client/helpers/message_helper.ex
@@ -73,4 +73,34 @@ defmodule DiscordEx.Client.Helpers.MessageHelper do
       |> User.dm_channels
       |> Enum.find(fn(c) -> String.to_integer(c["id"]) == channel_id end)
   end
+
+  @doc """
+  Actionable Mention and DM Message
+  This checks that an incoming message is private or is a mention to the current user.
+  ## Parameters
+    - payload: Data from the triggered event.
+    - state: Current state of bot.
+  ## Example
+      MessageHelper.actionable_message_for_me?(payload, state)
+      #=> true
+  """
+  @spec actionable_message_for_me?(map, map) :: boolean
+  def actionable_message_for_me?(payload, state) do
+
+    author_id = payload.data["author"]["id"]
+    channel_id  = payload.data["channel_id"]
+    mentions    = payload.data["mentions"]
+
+    if author_id != state[:client_id] do
+      _message_in_private_channel?(channel_id, state) || _message_mentions_me?(mentions, state)
+    else
+      false
+    end
+  end
+
+  defp _message_mentions_me?(mentions, state) do
+    Enum.find mentions, fn(m) ->
+      m["id"] == state[:client_id]
+    end
+  end
 end

--- a/lib/discord_ex/client/helpers/message_helper.ex
+++ b/lib/discord_ex/client/helpers/message_helper.ex
@@ -36,6 +36,30 @@ defmodule DiscordEx.Client.Helpers.MessageHelper do
   end
 
   @doc """
+  Actionable Mention and DM Message
+  This checks that an incoming message is private or is a mention to the current user.
+  ## Parameters
+    - payload: Data from the triggered event.
+    - state: Current state of bot.
+  ## Example
+      MessageHelper.actionable_message_for_me?(payload, state)
+      #=> true
+  """
+  @spec actionable_message_for_me?(map, map) :: boolean
+  def actionable_message_for_me?(payload, state) do
+
+    author_id = payload.data["author"]["id"]
+    channel_id  = payload.data["channel_id"]
+    mentions    = payload.data["mentions"]
+
+    if author_id != state[:client_id] do
+      _message_in_private_channel?(channel_id, state) || _message_mentions_me?(mentions, state)
+    else
+      false
+    end
+  end
+
+  @doc """
   Parses a message payload which is content leading with '!'.
   Returns a tuple with the command and the message.
 
@@ -72,30 +96,6 @@ defmodule DiscordEx.Client.Helpers.MessageHelper do
     state[:rest_client]
       |> User.dm_channels
       |> Enum.find(fn(c) -> String.to_integer(c["id"]) == channel_id end)
-  end
-
-  @doc """
-  Actionable Mention and DM Message
-  This checks that an incoming message is private or is a mention to the current user.
-  ## Parameters
-    - payload: Data from the triggered event.
-    - state: Current state of bot.
-  ## Example
-      MessageHelper.actionable_message_for_me?(payload, state)
-      #=> true
-  """
-  @spec actionable_message_for_me?(map, map) :: boolean
-  def actionable_message_for_me?(payload, state) do
-
-    author_id = payload.data["author"]["id"]
-    channel_id  = payload.data["channel_id"]
-    mentions    = payload.data["mentions"]
-
-    if author_id != state[:client_id] do
-      _message_in_private_channel?(channel_id, state) || _message_mentions_me?(mentions, state)
-    else
-      false
-    end
   end
 
   defp _message_mentions_me?(mentions, state) do


### PR DESCRIPTION
-   add state[:client_id] that contains user's ClientID as Integer
-   add actionable_message_for_me? to MessageHelper

This is simmilar function to #9 but thanks to `state[:client_id]` it's now faster and doesn't increase API usage (beware of rate limits)
