### PR TITLE
make path to dca-rs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ User.current(state[:rest_client])
 
 ## Voice Client Usage
 
-Keep in mind you will need to have [ffmpeg](https://ffmpeg.org) and [dca-rs](https://github.com/nstafie/dca-rs) installed and accessible from /usr/local/bin to use the audio feature.
+Keep in mind you will need to have [ffmpeg](https://ffmpeg.org) and [dca-rs](https://github.com/nstafie/dca-rs) installed.
+
+If your dca-rs is not installed as `/usr/local/bin/dca-rs` you can provide path
+to it in your `config.exs` with:
+```elixir
+config :discord_ex, dca_rs_path: "/your/path/dca-rs"
+```
 
 **For best results that include easy accessibility and efficient process management include voice information whenoy create your client.**
 

--- a/lib/discord_ex/voice/encoder.ex
+++ b/lib/discord_ex/voice/encoder.ex
@@ -7,7 +7,8 @@ defmodule DiscordEx.Voice.Encoder do
   @doc "Encode audio file to proper format"
   @spec encode_file(String.t, map) :: binary
   def encode_file(file_path, opts) do
-    %Proc{out: audio_stream} = Porcelain.spawn("/usr/local/bin/dca-rs",["--vol","#{opts[:volume]}","--ac","2","--ar","48000","--as","960","--ab","128","--raw","-i","#{file_path}"],[out: :stream])
+    dca_rs_path = Application.get_env(:discord_ex, :dca_rs_path)
+    %Proc{out: audio_stream} = Porcelain.spawn(dca_rs_path,["--vol","#{opts[:volume]}","--ac","2","--ar","48000","--as","960","--ab","128","--raw","-i","#{file_path}"],[out: :stream])
     audio_stream
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,8 @@ defmodule DiscordEx.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :httpoison, :porcelain]]
+    [applications: [:logger, :httpoison, :porcelain],
+     env: [dca_rs_path: "/usr/local/bin/dca-rs"]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
If your dca-rs is not in "/usr/local/bin/dca-rs" then you can
configure this in your config file via:
`config :discord_ex, dca_rs_path: "/your/path/dca-rs"`
