### PR TITLE
Correct return type of actionable_message_for* helpers.

### DIFF
--- a/lib/discord_ex/client/helpers/message_helper.ex
+++ b/lib/discord_ex/client/helpers/message_helper.ex
@@ -123,18 +123,16 @@ defmodule DiscordEx.Client.Helpers.MessageHelper do
   end
 
   defp _message_mentions_user?(mentions, username) do
-    Enum.find mentions, fn(m) -> m["username"] == username end
+    Enum.find(mentions, fn(m) -> m["username"] == username end) != nil
   end
 
   defp _message_in_private_channel?(channel_id, state) do
     state[:rest_client]
       |> User.dm_channels
-      |> Enum.find(fn(c) -> String.to_integer(c["id"]) == channel_id end)
+      |> Enum.find(fn(c) -> String.to_integer(c["id"]) == channel_id end) != nil
   end
 
   defp _message_mentions_me?(mentions, state) do
-    Enum.find mentions, fn(m) ->
-      m["id"] == state[:client_id]
-    end
+    Enum.find(mentions, fn(m) -> m["id"] == state[:client_id] end) != nil
   end
 end


### PR DESCRIPTION
The spec for `actionable_message_for?/3` and `actionable_message_for_me?/2` both explicitly state boolean for the return value.

However, `_message_in_private_channel?/2`, `_message_mentions_user?/2`, and `_message_mentions_me?/2` all return either a single item from the list `DiscordEx.RestClient.Resources.User.dm_channels/0` for the first or a single mention from `payload["mentions"]` for the second or third. 

The result is that you end up executing what is essentially `x || y` where `x` and `y` are either `nil` or some non-nil, non-boolean value.  The result is that you get back from the actionable helper functions either `x` if `x` is not `nil`, `y` if `x` is `nil` and `y` is not `nil`, or `nil` if both `x` and `y` are `nil`.

When using the if clause in Elixir, non-nil values are truthy and nil values are falsey, so you won't notice the error until you start leveraging case statements or the with clause, which use pattern matching.

This pull request fixes that by correcting the result of `Enum.find/2`.
