### PR TITLE
REST client start_link accepts optional GenServer parameters

### DIFF
--- a/lib/discord_ex/rest_client/rest_client.ex
+++ b/lib/discord_ex/rest_client/rest_client.ex
@@ -18,8 +18,8 @@ defmodule DiscordEx.RestClient do
   Start process and HTTP Client.
   {:ok, conn} = DiscordEx.RestClient.start_link(%{token: token})
   """
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
+  def start_link(opts, server_opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, server_opts)
   end
 
   @spec resource(pid, atom, String.t, map) :: request_reply


### PR DESCRIPTION
Add optional GenServer parameters to DiscordEx.RestClient.start_link(). This is convenient if a user wants to run the client inside a supervisor, since the process can then be registered to a name by the supervisor:

```
children = [
  worker(DiscordEx.RestClient, [%{token: "Bot " <> discord_token}, [name: DiscordRESTClient]])
]
```