### PR TITLE
Resolved warnings on Elixir 1.5

### DIFF
--- a/lib/discord_ex/client/helpers/message_helper.ex
+++ b/lib/discord_ex/client/helpers/message_helper.ex
@@ -81,7 +81,7 @@ defmodule DiscordEx.Client.Helpers.MessageHelper do
     msg =
       payload.data["content"]
       |> String.replace("!#{cmd}", "")
-      |> String.strip
+      |> String.trim
 
     {cmd, msg}
   end

--- a/lib/discord_ex/rest_client/rest.ex
+++ b/lib/discord_ex/rest_client/rest.ex
@@ -17,12 +17,12 @@ defmodule DiscordEx.Connections.REST do
   end
 
   defp process_request_headers(headers) when is_map(headers) do
-    merged_headers = Map.merge(standard_headers, headers)
+    merged_headers = Map.merge(standard_headers(), headers)
     Map.to_list(merged_headers)
   end
 
   defp process_request_headers(headers) do
-    Map.to_list(standard_headers) ++ headers
+    Map.to_list(standard_headers()) ++ headers
   end
 
   defp process_request_body(body) do

--- a/lib/discord_ex/voice/controller.ex
+++ b/lib/discord_ex/voice/controller.ex
@@ -10,7 +10,7 @@ defmodule DiscordEx.Voice.Controller do
 
   def listen_socket(voice_client) do
     task = Task.async fn ->
-      send(voice_client, {:get_state, :udp_socket_recv, self})
+      send(voice_client, {:get_state, :udp_socket_recv, self()})
       receive do
         {:udp_socket_recv, socket} -> socket
       end
@@ -19,8 +19,8 @@ defmodule DiscordEx.Voice.Controller do
   end
 
   def start(voice_client) do
-    {:ok, seq} = Agent.start_link(fn -> :random.uniform(93_920_290) end)
-    {:ok, time} = Agent.start_link(fn -> :random.uniform(83_290_239) end)
+    {:ok, seq} = Agent.start_link(fn -> :rand.uniform(93_920_290) end)
+    {:ok, time} = Agent.start_link(fn -> :rand.uniform(83_290_239) end)
 
     %{buffer: Buffer.start(),
       voice_client: voice_client,

--- a/lib/discord_ex/voice/udp.ex
+++ b/lib/discord_ex/voice/udp.ex
@@ -61,7 +61,7 @@ defmodule DiscordEx.Voice.UDP do
 
   defp _secret_key(voice_client) do
     task = Task.async fn ->
-      send(voice_client, {:get_state, :secret_key, self})
+      send(voice_client, {:get_state, :secret_key, self()})
       receive do
         {:secret_key, value} -> :erlang.list_to_binary(value)
       end
@@ -71,7 +71,7 @@ defmodule DiscordEx.Voice.UDP do
 
   defp _port(voice_client) do
     task = Task.async fn ->
-      send(voice_client, {:get_state, "port", self})
+      send(voice_client, {:get_state, "port", self()})
       receive do
         {"port", value} -> value
       end
@@ -81,7 +81,7 @@ defmodule DiscordEx.Voice.UDP do
 
   defp _address(voice_client) do
     task = Task.async fn ->
-      send(voice_client, {:get_state, :udp_ip_send, self})
+      send(voice_client, {:get_state, :udp_ip_send, self()})
       receive do
         {:udp_ip_send, value} -> Socket.Address.parse(value)
       end
@@ -91,7 +91,7 @@ defmodule DiscordEx.Voice.UDP do
 
   defp _ssrc(voice_client) do
     task = Task.async fn ->
-      send(voice_client, {:get_state, "ssrc", self})
+      send(voice_client, {:get_state, "ssrc", self()})
       receive do
         {"ssrc", value} -> value
       end
@@ -101,7 +101,7 @@ defmodule DiscordEx.Voice.UDP do
 
   def _send_socket(voice_client) do
     task = Task.async fn ->
-      send(voice_client, {:get_state, :udp_socket_send, self})
+      send(voice_client, {:get_state, :udp_socket_send, self()})
       receive do
         {:udp_socket_send, socket} -> socket
       end

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule DiscordEx.Mixfile do
      source_url: "https://github.com/rmcafee/discord_ex",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      docs: [extras: ["README.md"]]]
   end
 

--- a/test/discord_elixir/voice/buffer_test.exs
+++ b/test/discord_elixir/voice/buffer_test.exs
@@ -39,7 +39,7 @@ defmodule DiscordEx.Voice.BufferTest do
     Buffer.write(state[:buffer], <<2>>)
     Buffer.write(state[:buffer], <<3>>)
     Buffer.drain state[:buffer], 8, fn(data, time) ->
-      send self, {data, time}
+      send self(), {data, time}
     end
 
     assert_received {<<1>>, 0}
@@ -60,10 +60,10 @@ defmodule DiscordEx.Voice.BufferTest do
     Buffer.write(state[:buffer], packet_1)
     Buffer.write(state[:buffer], packet_2)
 
-    assert Buffer.size(state[:buffer]) == 60032 
+    assert Buffer.size(state[:buffer]) == 60032
 
     Buffer.drain_dca state[:buffer], fn(data, time) ->
-      send self, {data, time}
+      send self(), {data, time}
     end
 
     assert_received {<<0::size(p1_size_in_bits)>>, 0}


### PR DESCRIPTION
Most edits are adding parentheses to expand a variable name according
to the warning.

I also updated :random to :rand, String.strip to String.trim and
String.to_char_list to String.to_charlist as recommended by the
warnings.